### PR TITLE
feat: Use suggestion_snapshots in proposal generation (env rules)

### DIFF
--- a/app/services/suggestion/rule_engine.rb
+++ b/app/services/suggestion/rule_engine.rb
@@ -79,6 +79,5 @@
     def extract_triggers(condition_str, ctx)
       self.class.extract_triggers(condition_str, ctx)
     end
-
-  end
-end
+   end
+ end

--- a/app/services/suggestion/suggestion_engine.rb
+++ b/app/services/suggestion/suggestion_engine.rb
@@ -48,7 +48,7 @@ module Suggestion
       return nil if snapshots.empty?
 
       allowed_rule_keys = @rules.select { |r| r.category == "env" }.map(&:key).to_set
-      registry_by_key = ::Suggestion::RuleRegistry.all.to_h { |r| [r.key, r] }
+      registry_by_key = ::Suggestion::RuleRegistry.all.to_h { |r| [ r.key, r ] }
 
       snapshots
         .select { |s| allowed_rule_keys.include?(s.rule_key) }

--- a/spec/factories/suggestion_snapshots.rb
+++ b/spec/factories/suggestion_snapshots.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     rule_key { "heatstroke_Warning" }
     title { "暑い日。炎天下を避け、激しい運動は中止" }
     message { "外出時は炎天下を避け、室内では室温の上昇に注意する。激しい運動は中止。" }
-    tags { ["temperature", "heatstroke"] }
+    tags { [ "temperature", "heatstroke" ] }
     severity { 75 }
     category { "env" }
     metadata do

--- a/spec/services/suggestion/suggestion_engine_spec.rb
+++ b/spec/services/suggestion/suggestion_engine_spec.rb
@@ -422,7 +422,7 @@ RSpec.describe Suggestion::SuggestionEngine do
                  rule_key: 'heatstroke_Warning',
                  title: '暑い日。炎天下を避け、激しい運動は中止',
                  message: '外出時は炎天下を避け、室内では室温の上昇に注意する。激しい運動は中止。',
-                 tags: ['temperature', 'heatstroke'],
+                 tags: [ 'temperature', 'heatstroke' ],
                  severity: 75,
                  category: 'env',
                  metadata: {
@@ -442,7 +442,7 @@ RSpec.describe Suggestion::SuggestionEngine do
                  rule_key: 'comfort_Temperature',
                  title: '過ごしやすい気温です。今日は整いやすい日',
                  message: '気温が快適な範囲です。',
-                 tags: ['temperature', 'positive'],
+                 tags: [ 'temperature', 'positive' ],
                  severity: 35,
                  category: 'env',
                  metadata: {
@@ -533,7 +533,7 @@ RSpec.describe Suggestion::SuggestionEngine do
         let!(:heatstroke_topic) do
           ConcernTopic.find_or_create_by!(key: 'heatstroke') do |c|
             c.label_ja = "熱中症"
-            c.rule_concerns = ["heatstroke"]
+            c.rule_concerns = [ "heatstroke" ]
             c.position = 1
             c.active = true
           end
@@ -548,7 +548,7 @@ RSpec.describe Suggestion::SuggestionEngine do
                  rule_key: 'heatstroke_Warning',
                  title: '暑い日。炎天下を避け、激しい運動は中止',
                  message: '外出時は炎天下を避け、室内では室温の上昇に注意する。激しい運動は中止。',
-                 tags: ['temperature', 'heatstroke'],
+                 tags: [ 'temperature', 'heatstroke' ],
                  severity: 75,
                  category: 'env',
                  metadata: { 'temperature_c' => 32.0, 'humidity_pct' => 50.0, 'pressure_hpa' => 1013.0 })
@@ -558,7 +558,7 @@ RSpec.describe Suggestion::SuggestionEngine do
                  rule_key: 'weather_pain_drop_Warning',
                  title: '急激な気圧低下です。酔い止めや休憩の準備を',
                  message: '急激な気圧低下です。酔い止めや休憩の準備を。',
-                 tags: ['pressure', 'weather_pain'],
+                 tags: [ 'pressure', 'weather_pain' ],
                  severity: 85,
                  category: 'env',
                  metadata: { 'max_pressure_drop_1h_awake' => -3.5, 'humidity_pct' => 50.0, 'pressure_hpa' => 1013.0 })


### PR DESCRIPTION
# 概要

提案生成時に suggestion_snapshots を参照するように変更。env ルールは suggestion_snapshots から取得し、body ルールは従来どおり RuleEngine で生成。API レスポンスの高速化と当日・同一都道府県内の一貫性を実現する。

# 目的

- suggestion_snapshots を env ソースとして利用し、API レスポンスの高速化
- 7:30 に計算した env データの活用
- 同一日・同一都道府県内の一貫性確保

# 変更内容

- SuggestionEngine: suggestion_snapshots から env を取得し、body とマージして返す
- 7:30 前など snapshots が空の場合は RuleEngine でフォールバック
- rule_key で関心トピックフィルタを適用
- metadata から triggers を構築
- RuleEngine に pick_top / extract_triggers のクラスメソッドを追加
- suggestion_snapshots の factory と spec を追加

# 影響範囲

| レイヤー | 影響 |
|----------|------|
| **back** | SuggestionEngine の変更のみ |
| **front** | 変更なし（API レスポンス形式は維持） |
| **DB** | 変更なし（suggestion_snapshots を参照するのみ） |