### PR TITLE
feat: Add morning push notification at 8:00 (MorningNotificationJob)

### DIFF
--- a/app/jobs/morning_notification_job.rb
+++ b/app/jobs/morning_notification_job.rb
@@ -1,0 +1,20 @@
+# Job to send morning push notification at scheduled time
+class MorningNotificationJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    Rails.logger.info "Starting morning notification job..."
+
+    title = "今日の行動提案"
+    body = "今日の行動のヒントを確認しましょう"
+    options = {
+      icon: "/icon-192x192.png",
+      badge: "/badge-72x72.png",
+      data: { url: "/dashboard" }
+    }
+
+    PushNotificationService.send_to_all(title, body, options)
+
+    Rails.logger.info "Morning notification job completed."
+  end
+end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -28,6 +28,11 @@ every 1.day, at: "7:30 am" do
   runner "MorningSuggestionJob.perform_now"
 end
 
+# 朝のプッシュ通知（8:00）
+every 1.day, at: "8:00 am" do
+  runner "MorningNotificationJob.perform_now"
+end
+
 # Send daily reminder notification at 8:00 PM (20:00) every day
 every 1.day, at: "8:00 pm" do
   runner "DailyReminderJob.perform_now"

--- a/spec/jobs/morning_notification_job_spec.rb
+++ b/spec/jobs/morning_notification_job_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe MorningNotificationJob, type: :job do
+  describe "#perform" do
+    let(:title) { "今日の行動提案" }
+    let(:body) { "今日の行動のヒントを確認しましょう" }
+    let(:expected_options) do
+      {
+        icon: "/icon-192x192.png",
+        badge: "/badge-72x72.png",
+        data: { url: "/dashboard" }
+      }
+    end
+
+    it "calls PushNotificationService.send_to_all with correct parameters" do
+      expect(PushNotificationService).to receive(:send_to_all).with(
+        title,
+        body,
+        expected_options
+      )
+
+      described_class.perform_now
+    end
+
+    it "logs the start and completion" do
+      allow(PushNotificationService).to receive(:send_to_all)
+
+      allow(Rails.logger).to receive(:info).and_call_original
+
+      expect {
+        described_class.perform_now
+      }.not_to raise_error
+    end
+  end
+
+  describe "queue configuration" do
+    it "is set to the default queue" do
+      expect(described_class.new.queue_name).to eq("default")
+    end
+  end
+end


### PR DESCRIPTION
# 概要

朝8時のプッシュ通知（MorningNotificationJob）を新規実装する。現状は夜20時の1回のみで、UI では「朝7時・夜20時の2回」と案内しており乖離しているため、朝8時のプッシュを追加して実装とUIを一致させる。

# 目的

- 朝8時にプッシュ通知を送信するジョブを新規作成
- schedule.rb に 8:00 の実行スケジュールを追加
- 夜の DailyReminderJob（20:00）は従来どおり維持

# 変更内容

- MorningNotificationJob の新規作成（app/jobs/morning_notification_job.rb）
- schedule.rb に 8:00 の MorningNotificationJob 実行を追加
- MorningNotificationJob の spec 追加

# 影響範囲

- 通知を有効にしている全ユーザー（朝8時にプッシュが届く）

# 関連ブランチ名

feat/back/morning-notification-and-copy
