### PR TITLE
feat: Add level and tags to weekly report suggestions API

### DIFF
--- a/app/services/reports/weekly_report_service.rb
+++ b/app/services/reports/weekly_report_service.rb
@@ -131,7 +131,9 @@ module Reports
             title: s.title,
             message: s.message,
             helpfulness: fb&.helpfulness,
-            category: s.category
+            category: s.category,
+            level: s.level,
+            tags: s.tags || []
           }
         end
 


### PR DESCRIPTION
# 概要

週次レポートAPIの `aggregate_suggestions` で `level` と `tags` を返すように修正する。

# 目的

- 週間レポートの提案カードをダッシュボードと同様のスタイルで表示するため、front に `level` を渡す。
- 提案グラフを level ごとの積み上げ棒グラフにするため、日別の提案データに `level` が必要。
- タグ表示のため `tags` も返却する。

# 変更内容

- `WeeklyReportService#aggregate_suggestions` の返却に `level` と `tags` を追加
- `DailyLogSuggestion` の `level` カラムと `tags` カラムを返却に含める

# 影響範囲

- 週次レポートAPIのレスポンス形式（`suggestions.by_day[].items[]` に `level`, `tags` を追加）

# 関連ブランチ名

- `feat/back/weekly-report-suggestions-style`
