### PR TITLE
Add global error handling and fix DailyLogsController error handling

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,30 @@
 class ApplicationController < ActionController::API
   before_action :set_security_headers
 
+  # グローバルエラーハンドリング（宣言順: 汎用→具体的。後に書いたものが先にマッチ）
+  rescue_from StandardError do |e|
+    Rails.logger.error "[UnhandledError] #{e.class}: #{e.message}"
+    Rails.logger.error e.backtrace&.first(20)&.join("\n")
+    render json: { error: "internal_error", message: "サーバーエラーが発生しました" },
+           status: :internal_server_error
+  end
+
+  rescue_from ActionController::ParameterMissing do |e|
+    render json: { error: "parameter_missing", message: e.message },
+           status: :bad_request
+  end
+
+  rescue_from ActiveRecord::RecordInvalid do |e|
+    render json: { error: "validation_error", message: e.message,
+                   details: e.record.errors.messages },
+           status: :unprocessable_entity
+  end
+
+  rescue_from ActiveRecord::RecordNotFound do |e|
+    render json: { error: "not_found", message: "リソースが見つかりません" },
+           status: :not_found
+  end
+
   private
 
   def set_security_headers


### PR DESCRIPTION
# 概要
ApplicationControllerにグローバルエラーハンドリングを追加し、DailyLogsControllerの既知のエラー処理問題を修正する。

# 目的
- 予期しない例外がユーザーに生のエラー情報として返されないようにする
- エラー時のログ出力を標準化する
- DailyLogsControllerのトランザクション構造・JSONパース処理の問題を修正する

# 変更内容
- `ApplicationController` に `rescue_from` でグローバルエラーハンドリングを追加
  - `ActiveRecord::RecordNotFound` → 404
  - `ActiveRecord::RecordInvalid` → 422
  - `ActionController::ParameterMissing` → 400
  - `StandardError` → 500（セーフティネット）
- `DailyLogsController#evening` のトランザクション内 `render`/`return` をトランザクション外に移動
- `JSON.parse(...) rescue []` を `JSON::ParserError` 限定のrescueに変更しログ出力を追加

# 影響範囲
- 全コントローラ（グローバルハンドリングによるセーフティネット追加）
- `DailyLogsController#evening`（トランザクション構造・JSONパース処理）

# 関連ブランチ名
- `fix/global-error-handling`

Closes #82