### PR TITLE
Unify error response format to { error, message, details }

### DIFF
--- a/app/controllers/api/v1/daily_logs_controller.rb
+++ b/app/controllers/api/v1/daily_logs_controller.rb
@@ -72,7 +72,7 @@ class Api::V1::DailyLogsController < ApplicationController
         include: [ :prefecture, { suggestion_feedbacks: { methods: [ :suggestion_key ] } } ]
       )
     else
-      render json: { error: "指定された日付のデイリーログが見つかりません" },
+      render json: { error: "not_found", message: "指定された日付のデイリーログが見つかりません" },
              status: :not_found
     end
   end
@@ -130,7 +130,8 @@ class Api::V1::DailyLogsController < ApplicationController
       render json: @daily_log.as_json(include: [ :prefecture ]),
              status: :created
     else
-      render json: { errors: @daily_log.errors.full_messages },
+      render json: { error: "validation_error", message: "入力内容に誤りがあります",
+                     details: @daily_log.errors.messages },
              status: :unprocessable_entity
     end
   end
@@ -155,7 +156,8 @@ class Api::V1::DailyLogsController < ApplicationController
     if @daily_log.save
       render json: @daily_log.as_json(include: [ :prefecture ])
     else
-      render json: { errors: @daily_log.errors.full_messages },
+      render json: { error: "validation_error", message: "入力内容に誤りがあります",
+                     details: @daily_log.errors.messages },
              status: :unprocessable_entity
     end
   end
@@ -164,14 +166,15 @@ class Api::V1::DailyLogsController < ApplicationController
   def update_self_score
     self_score_value = params[:self_score]&.to_i
     unless self_score_value.nil? || (1..3).cover?(self_score_value)
-      return render json: { errors: [ "self_scoreは1〜3の範囲で指定してください" ] },
+      return render json: { error: "validation_error", message: "self_scoreは1〜3の範囲で指定してください" },
                     status: :unprocessable_entity
     end
 
     if @daily_log.update(self_score: self_score_value)
       render json: @daily_log.as_json(include: [ :prefecture ])
     else
-      render json: { errors: @daily_log.errors.full_messages },
+      render json: { error: "validation_error", message: "入力内容に誤りがあります",
+                     details: @daily_log.errors.messages },
              status: :unprocessable_entity
     end
   end
@@ -225,7 +228,8 @@ class Api::V1::DailyLogsController < ApplicationController
     if @daily_log.save
       render json: { status: "ok", next: "/dashboard" }, status: :ok
     else
-      render json: { errors: @daily_log.errors.full_messages },
+      render json: { error: "validation_error", message: "入力内容に誤りがあります",
+                     details: @daily_log.errors.messages },
              status: :unprocessable_entity
     end
   end
@@ -320,7 +324,8 @@ class Api::V1::DailyLogsController < ApplicationController
       Rails.logger.info "Evening reflection saved successfully for daily_log #{@daily_log.id}"
       render json: { status: "ok", next: "/dashboard" }, status: :ok
     else
-      render json: { errors: @daily_log.errors.full_messages },
+      render json: { error: "validation_error", message: "入力内容に誤りがあります",
+                     details: @daily_log.errors.messages },
              status: :unprocessable_entity
     end
   end

--- a/app/controllers/api/v1/forecasts_controller.rb
+++ b/app/controllers/api/v1/forecasts_controller.rb
@@ -7,7 +7,7 @@ class Api::V1::ForecastsController < ApplicationController
   #   hours: 取得したい件数（省略時は24、最大48など）
   def index
     unless current_user&.prefecture
-      render json: { error: "prefecture_not_set" }, status: :unprocessable_entity
+      render json: { error: "prefecture_not_set", message: "都道府県が設定されていません" }, status: :unprocessable_entity
       return
     end
 

--- a/app/controllers/api/v1/prefectures_controller.rb
+++ b/app/controllers/api/v1/prefectures_controller.rb
@@ -10,6 +10,6 @@ class Api::V1::PrefecturesController < ApplicationController
     @prefecture = Prefecture.find(params[:id])
     render json: @prefecture
   rescue ActiveRecord::RecordNotFound
-    render json: { error: "Prefecture not found" }, status: :not_found
+    render json: { error: "not_found", message: "都道府県が見つかりません" }, status: :not_found
   end
 end

--- a/app/controllers/api/v1/push_subscriptions_controller.rb
+++ b/app/controllers/api/v1/push_subscriptions_controller.rb
@@ -10,7 +10,8 @@ module Api
         if subscription.save
           render json: { message: "Successfully subscribed to push notifications", subscription: subscription }, status: :created
         else
-          render json: { errors: subscription.errors.full_messages }, status: :unprocessable_entity
+          render json: { error: "validation_error", message: "通知の登録に失敗しました",
+                         details: subscription.errors.messages }, status: :unprocessable_entity
         end
       end
 
@@ -22,7 +23,7 @@ module Api
           subscription.destroy
           render json: { message: "Successfully unsubscribed from push notifications" }, status: :ok
         else
-          render json: { error: "Subscription not found" }, status: :not_found
+          render json: { error: "not_found", message: "通知の登録が見つかりません" }, status: :not_found
         end
       end
 

--- a/app/controllers/api/v1/registrations_controller.rb
+++ b/app/controllers/api/v1/registrations_controller.rb
@@ -17,7 +17,8 @@ class Api::V1::RegistrationsController < ApplicationController
         is_new_user: true
       }, status: :created
     else
-      render json: { errors: user.errors.full_messages }, status: :unprocessable_entity
+      render json: { error: "validation_error", message: "登録内容に誤りがあります",
+                     details: user.errors.messages }, status: :unprocessable_entity
     end
   end
 
@@ -65,7 +66,8 @@ class Api::V1::RegistrationsController < ApplicationController
       }, status: :created
     end
   rescue ActiveRecord::RecordInvalid => e
-    render json: { errors: [ e.record.errors.full_messages.presence || e.message ].flatten }, status: :unprocessable_entity
+    render json: { error: "validation_error", message: e.message,
+                   details: e.record.errors.messages }, status: :unprocessable_entity
   end
 
   private

--- a/app/controllers/api/v1/reports_controller.rb
+++ b/app/controllers/api/v1/reports_controller.rb
@@ -7,7 +7,7 @@ class Api::V1::ReportsController < ApplicationController
       begin
         Date.parse(params[:start])
       rescue ArgumentError
-        render json: { error: "無効な日付形式です。YYYY-MM-DD形式で指定してください。" },
+        render json: { error: "invalid_date", message: "無効な日付形式です。YYYY-MM-DD形式で指定してください。" },
                status: :bad_request
         return
       end

--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -13,7 +13,8 @@ class Api::V1::SessionsController < ApplicationController
     if token.blank?
       render json: {
         valid: false,
-        error: "認証トークンが提供されていません"
+        error: "unauthorized",
+        message: "認証トークンが提供されていません"
       }, status: :unauthorized
       return
     end
@@ -23,7 +24,8 @@ class Api::V1::SessionsController < ApplicationController
     if payload.nil?
       render json: {
         valid: false,
-        error: "無効な認証トークンです"
+        error: "unauthorized",
+        message: "無効な認証トークンです"
       }, status: :unauthorized
       return
     end
@@ -32,7 +34,8 @@ class Api::V1::SessionsController < ApplicationController
     unless Auth::JwtService.token_valid?(token)
       render json: {
         valid: false,
-        error: "認証トークンの有効期限が切れています"
+        error: "unauthorized",
+        message: "認証トークンの有効期限が切れています"
       }, status: :unauthorized
       return
     end
@@ -41,7 +44,8 @@ class Api::V1::SessionsController < ApplicationController
     unless Auth::JwtService.access_token?(token)
       render json: {
         valid: false,
-        error: "アクセストークンが必要です"
+        error: "unauthorized",
+        message: "アクセストークンが必要です"
       }, status: :unauthorized
       return
     end
@@ -51,7 +55,8 @@ class Api::V1::SessionsController < ApplicationController
     if user.nil?
       render json: {
         valid: false,
-        error: "無効な認証トークンです"
+        error: "unauthorized",
+        message: "無効な認証トークンです"
       }, status: :unauthorized
       return
     end
@@ -66,7 +71,8 @@ class Api::V1::SessionsController < ApplicationController
     Rails.logger.error "Token validation error: #{e.message}"
     render json: {
       valid: false,
-      error: "認証処理中にエラーが発生しました"
+      error: "internal_error",
+      message: "認証処理中にエラーが発生しました"
     }, status: :internal_server_error
   end
 
@@ -101,14 +107,15 @@ class Api::V1::SessionsController < ApplicationController
       }, status: :ok
     else
       render json: {
-        error: "認証に失敗しました",
-        details: "OAuthユーザーが見つかりません"
+        error: "unauthorized",
+        message: "OAuthユーザーが見つかりません"
       }, status: :unauthorized
     end
   rescue => e
     Rails.logger.error "OAuth authentication error: #{e.message}"
     render json: {
-      error: "認証処理中にエラーが発生しました"
+      error: "internal_error",
+      message: "認証処理中にエラーが発生しました"
     }, status: :internal_server_error
   end
 
@@ -117,8 +124,8 @@ class Api::V1::SessionsController < ApplicationController
 
     if user.nil?
       render json: {
-        error: "認証に失敗しました",
-        details: "メールアドレスまたはパスワードが正しくありません"
+        error: "unauthorized",
+        message: "メールアドレスまたはパスワードが正しくありません"
       }, status: :unauthorized
       return
     end
@@ -138,14 +145,15 @@ class Api::V1::SessionsController < ApplicationController
       }, status: :ok
     else
       render json: {
-        error: "認証に失敗しました",
-        details: "メールアドレスまたはパスワードが正しくありません"
+        error: "unauthorized",
+        message: "メールアドレスまたはパスワードが正しくありません"
       }, status: :unauthorized
     end
   rescue => e
     Rails.logger.error "Email authentication error: #{e.message}"
     render json: {
-      error: "認証処理中にエラーが発生しました"
+      error: "internal_error",
+      message: "認証処理中にエラーが発生しました"
     }, status: :internal_server_error
   end
 end

--- a/app/controllers/api/v1/suggestions_controller.rb
+++ b/app/controllers/api/v1/suggestions_controller.rb
@@ -9,14 +9,12 @@ class Api::V1::SuggestionsController < ApplicationController
       Suggestion::SuggestionPersistence.call(daily_log: daily_log, suggestions: suggestions)
       render json: suggestions.map { |s| serialize(s) }
     rescue ArgumentError => e
-      # 日付のパースエラー
-      render json: { error: "無効な日付形式です" }, status: :bad_request
+      render json: { error: "invalid_date", message: "無効な日付形式です" }, status: :bad_request
     rescue ActiveRecord::RecordNotFound => e
-      # DailyLogが見つからない場合
-      render json: { error: "指定された日付のログが見つかりません" }, status: :not_found
+      render json: { error: "not_found", message: "指定された日付のログが見つかりません" }, status: :not_found
     rescue => e
       Rails.logger.error("[Suggestions] Error: #{e.class} #{e.message}")
-      render json: { error: "提案の取得に失敗しました" }, status: :internal_server_error
+      render json: { error: "internal_error", message: "提案の取得に失敗しました" }, status: :internal_server_error
     end
   end
 

--- a/app/controllers/api/v1/user_concern_topics_controller.rb
+++ b/app/controllers/api/v1/user_concern_topics_controller.rb
@@ -40,7 +40,7 @@ class Api::V1::UserConcernTopicsController < ApplicationController
 
     head :no_content
   rescue ActiveRecord::RecordInvalid => e
-    render json: { error: e.message }, status: :unprocessable_entity
+    render json: { error: "validation_error", message: e.message }, status: :unprocessable_entity
   end
 
   private

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -24,19 +24,22 @@ class Api::V1::UsersController < ApplicationController
       }, status: :ok
     else
       render json: {
-        errors: current_user.errors.full_messages,
-        field_errors: current_user.errors.messages
+        error: "validation_error",
+        message: "入力内容に誤りがあります",
+        details: current_user.errors.messages
       }, status: :unprocessable_entity
     end
   rescue ActiveRecord::RecordInvalid => e
     render json: {
-      errors: [ e.message ],
-      field_errors: e.record.errors.messages
+      error: "validation_error",
+      message: e.message,
+      details: e.record.errors.messages
     }, status: :unprocessable_entity
   rescue => e
     Rails.logger.error "User update error: #{e.message}"
     render json: {
-      errors: [ "ユーザー情報の更新中にエラーが発生しました" ]
+      error: "internal_error",
+      message: "ユーザー情報の更新中にエラーが発生しました"
     }, status: :internal_server_error
   end
 

--- a/app/controllers/concerns/authenticatable.rb
+++ b/app/controllers/concerns/authenticatable.rb
@@ -58,7 +58,7 @@ module Authenticatable
 
   def render_unauthorized(message)
     render json: {
-      error: "認証エラー",
+      error: "unauthorized",
       message: message
     }, status: :unauthorized
   end

--- a/spec/requests/api/v1/prefectures_controller_spec.rb
+++ b/spec/requests/api/v1/prefectures_controller_spec.rb
@@ -61,7 +61,8 @@ RSpec.describe 'Api::V1::Prefectures', type: :request do
         expect(response).to have_http_status(:not_found)
 
         json_response = JSON.parse(response.body)
-        expect(json_response['error']).to eq('Prefecture not found')
+        expect(json_response['error']).to eq('not_found')
+        expect(json_response['message']).to eq('都道府県が見つかりません')
       end
     end
   end

--- a/spec/requests/api/v1/push_subscriptions_spec.rb
+++ b/spec/requests/api/v1/push_subscriptions_spec.rb
@@ -37,7 +37,8 @@ RSpec.describe "Api::V1::PushSubscriptions", type: :request do
 
         expect(response).to have_http_status(:unprocessable_entity)
         json = JSON.parse(response.body)
-        expect(json["errors"]).to be_present
+        expect(json["error"]).to eq("validation_error")
+        expect(json["details"]).to be_present
       end
     end
 
@@ -51,7 +52,8 @@ RSpec.describe "Api::V1::PushSubscriptions", type: :request do
 
         expect(response).to have_http_status(:unprocessable_entity)
         json = JSON.parse(response.body)
-        expect(json["errors"]).to include(match(/Endpoint has already been taken/))
+        expect(json["error"]).to eq("validation_error")
+        expect(json["details"]["endpoint"]).to be_present
       end
     end
 

--- a/spec/requests/api/v1/reports_controller_spec.rb
+++ b/spec/requests/api/v1/reports_controller_spec.rb
@@ -124,7 +124,8 @@ RSpec.describe "Api::V1::Reports", type: :request do
 
           expect(response).to have_http_status(:bad_request)
           json = JSON.parse(response.body)
-          expect(json["error"]).to include("無効な日付形式")
+          expect(json["error"]).to eq("invalid_date")
+          expect(json["message"]).to include("無効な日付形式")
         end
       end
     end

--- a/spec/requests/api/v1/sessions_controller_spec.rb
+++ b/spec/requests/api/v1/sessions_controller_spec.rb
@@ -27,7 +27,8 @@ RSpec.describe "Api::V1::SessionsController", type: :request do
         expect(response).to have_http_status(:unauthorized)
         json = JSON.parse(response.body)
         expect(json["valid"]).to be false
-        expect(json["error"]).to eq("認証トークンが提供されていません")
+        expect(json["error"]).to eq("unauthorized")
+        expect(json["message"]).to eq("認証トークンが提供されていません")
       end
     end
 
@@ -39,7 +40,8 @@ RSpec.describe "Api::V1::SessionsController", type: :request do
         expect(response).to have_http_status(:unauthorized)
         json = JSON.parse(response.body)
         expect(json["valid"]).to be false
-        expect(json["error"]).to eq("無効な認証トークンです")
+        expect(json["error"]).to eq("unauthorized")
+        expect(json["message"]).to eq("無効な認証トークンです")
       end
     end
 
@@ -61,7 +63,8 @@ RSpec.describe "Api::V1::SessionsController", type: :request do
         expect(response).to have_http_status(:unauthorized)
         json = JSON.parse(response.body)
         expect(json["valid"]).to be false
-        expect(json["error"]).to eq("認証トークンの有効期限が切れています")
+        expect(json["error"]).to eq("unauthorized")
+        expect(json["message"]).to eq("認証トークンの有効期限が切れています")
       end
     end
 
@@ -83,7 +86,8 @@ RSpec.describe "Api::V1::SessionsController", type: :request do
         expect(response).to have_http_status(:unauthorized)
         json = JSON.parse(response.body)
         expect(json["valid"]).to be false
-        expect(json["error"]).to eq("アクセストークンが必要です")
+        expect(json["error"]).to eq("unauthorized")
+        expect(json["message"]).to eq("アクセストークンが必要です")
       end
     end
 
@@ -105,7 +109,8 @@ RSpec.describe "Api::V1::SessionsController", type: :request do
         expect(response).to have_http_status(:unauthorized)
         json = JSON.parse(response.body)
         expect(json["valid"]).to be false
-        expect(json["error"]).to eq("無効な認証トークンです")
+        expect(json["error"]).to eq("unauthorized")
+        expect(json["message"]).to eq("無効な認証トークンです")
       end
     end
 
@@ -117,7 +122,8 @@ RSpec.describe "Api::V1::SessionsController", type: :request do
         expect(response).to have_http_status(:unauthorized)
         json = JSON.parse(response.body)
         expect(json["valid"]).to be false
-        expect(json["error"]).to eq("認証トークンが提供されていません")
+        expect(json["error"]).to eq("unauthorized")
+        expect(json["message"]).to eq("認証トークンが提供されていません")
       end
     end
   end

--- a/spec/requests/api/v1/suggestions_controller_spec.rb
+++ b/spec/requests/api/v1/suggestions_controller_spec.rb
@@ -141,8 +141,8 @@ RSpec.describe 'Api::V1::Suggestions', type: :request do
 
           expect(response).to have_http_status(:not_found)
           json = JSON.parse(response.body)
-          expect(json).to have_key('error')
-          expect(json['error']).to include('見つかりません')
+          expect(json['error']).to eq('not_found')
+          expect(json['message']).to include('見つかりません')
         end
       end
     end


### PR DESCRIPTION
# 概要
全コントローラのエラーレスポンスを統一形式に修正する。

# 目的
エラーレスポンスのJSON形式がバラバラだったものを統一し、フロントエンドのパース処理を簡潔にする。

# 変更内容
- 全コントローラのエラーレスポンスを `{ error: "コード", message: "メッセージ", details?: {} }` に統一
- `error` キーに機械可読なエラーコード（`not_found`, `validation_error`, `unauthorized` 等）
- `message` キーにユーザー向け日本語メッセージ
- バリデーションエラー時は `details` キーにフィールド別エラーを格納
- 既存テストを新形式に合わせて修正（11テスト）

# 影響範囲
- 全コントローラ（11ファイル）、Authenticatable concern
- テスト（5ファイル）
- フロントエンド側も合わせて修正（Climode_front #73）

# 関連ブランチ名
- back: `refactor/unify-error-response`
- front: `refactor/unify-error-parsing`

Closes #84