### PR TITLE
Fix job retry strategy

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,7 +1,4 @@
 class ApplicationJob < ActiveJob::Base
-  # Automatically retry jobs that encountered a deadlock
-  # retry_on ActiveRecord::Deadlocked
-
-  # Most jobs are safe to ignore if the underlying records are no longer available
-  # discard_on ActiveJob::DeserializationError
+  retry_on ActiveRecord::Deadlocked, wait: 5.seconds, attempts: 3
+  discard_on ActiveJob::DeserializationError
 end


### PR DESCRIPTION
# 概要
ジョブにリトライ戦略とエラーログ出力を追加

# 目的
一時的な障害（ネットワークエラー等）でジョブが失敗した際にリトライされるようにし、失敗をログで検知できるようにする

# 変更内容
- `ApplicationJob` に `retry_on ActiveRecord::Deadlocked` と `discard_on ActiveJob::DeserializationError` を設定
- `MorningNotificationJob` / `DailyReminderJob` に `retry_on Net::OpenTimeout, Net::ReadTimeout` を追加
- 通知系ジョブに `rescue => e` でエラーログ出力後 `raise` で再送出するハンドリングを追加

# 影響範囲
- バックグラウンドジョブの障害時挙動

# 関連ブランチ名
fix/job-retry-strategy

Closes #86