### PR TITLE
Fix weather API error handling

### DIFF
--- a/app/services/weather/weather_snapshot_service.rb
+++ b/app/services/weather/weather_snapshot_service.rb
@@ -22,8 +22,12 @@ module Weather
     def self.update_all_prefectures(date = Date.current)
       Prefecture.find_each do |prefecture|
         update_for_prefecture(prefecture, date)
+      rescue Net::OpenTimeout => e
+        Rails.logger.error "[Weather] Connection timeout updating snapshot for prefecture #{prefecture.id}: #{e.message}"
+      rescue Net::ReadTimeout => e
+        Rails.logger.error "[Weather] Read timeout updating snapshot for prefecture #{prefecture.id}: #{e.message}"
       rescue => e
-        Rails.logger.error "Failed to update WeatherSnapshot for prefecture #{prefecture.id}: #{e.message}"
+        Rails.logger.error "[Weather] Failed to update snapshot for prefecture #{prefecture.id}: #{e.class} - #{e.message}"
       end
     end
 

--- a/spec/services/weather_data_service_spec.rb
+++ b/spec/services/weather_data_service_spec.rb
@@ -85,21 +85,23 @@ RSpec.describe Weather::WeatherDataService do
         it 'エラーログを出力してダミーデータを返す' do
           result = service.fetch_weather_data
 
-          expect(Rails.logger).to have_received(:error).with(/Weather API error/)
+          expect(Rails.logger).to have_received(:error).with(/\[Weather\] Unexpected error/)
           expect(result[:snapshot][:source]).to eq('dummy_data')
         end
       end
 
       context 'APIレスポンスが失敗の場合' do
-        let(:mock_response) { double(success?: false) }
+        let(:mock_response) { double(success?: false, code: 500) }
 
         before do
           allow(described_class).to receive(:get).and_return(mock_response)
+          allow(Rails.logger).to receive(:warn)
         end
 
         it 'ダミーデータを返す' do
           result = service.fetch_weather_data
 
+          expect(Rails.logger).to have_received(:warn).with(/\[Weather\] HTTP error 500/)
           expect(result[:snapshot][:source]).to eq('dummy_data')
         end
       end
@@ -269,17 +271,18 @@ RSpec.describe Weather::WeatherDataService do
         it 'エラーログを出力してダミー時系列を返す' do
           result = service.fetch_forecast_series(hours: 3)
 
-          expect(Rails.logger).to have_received(:error).with(/Weather API \(series\) error/)
+          expect(Rails.logger).to have_received(:error).with(/\[Weather\] Unexpected error \(series\)/)
           expect(result.size).to eq(3)
           expect(result.first[:time]).to be_a(DateTime)
         end
       end
 
       context 'APIレスポンスが失敗の場合' do
-        let(:mock_response) { double(success?: false) }
+        let(:mock_response) { double(success?: false, code: 503) }
 
         before do
           allow(described_class).to receive(:get).and_return(mock_response)
+          allow(Rails.logger).to receive(:warn)
         end
 
         it 'ダミー時系列データを返す' do


### PR DESCRIPTION
# 概要
Weather系サービスの大雑把なrescueを例外種類別に分離

# 目的
- ログから障害原因（タイムアウト/HTTPエラー/JSONパースエラー）を特定できるようにする
- 将来的にタイムアウトだけリトライする等の制御を可能にする

# 変更内容
- `WeatherDataService`: `fetch_weather_data` / `fetch_forecast_series` のrescueを `Net::OpenTimeout`, `Net::ReadTimeout`, `JSON::ParserError` に分離
- `WeatherDataService`: HTTPエラー時にステータスコードをログに記録
- `WeatherSnapshotService`: `update_all_prefectures` のrescueをタイムアウト別に分離
- ログプレフィックスを `[Weather]` に統一
- テストを新しいログ形式に合わせて修正

# 影響範囲
- 天気データ取得時のエラーハンドリング（既存の挙動は変わらずダミーデータへフォールバック）

# 関連ブランチ名
fix/weather-api-error-handling

Closes #88