### PR TITLE
Rename concern word to concern topic in Japanese labels

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -148,8 +148,8 @@ else
   puts "  WARNING: health_rules.yml not found, skipping suggestion_rules"
 end
 
-# 関心テーママスタ（関心ワード）
-# label_ja, description_ja はフロントの関心ワード登録UIで表示されます。
+# 関心テーママスタ（関心トピック）
+# label_ja, description_ja はフロントの関心トピック登録UIで表示されます。
 unless is_production
   puts "Seeding concern topics..."
 
@@ -197,7 +197,7 @@ unless is_production
     topic.save!
   end
 
-  # Alice に全関心ワードを登録
+  # Alice に全関心トピックを登録
   alice = User.find_by(email: 'alice@example.com')
   if alice
     ConcernTopic.find_each do |topic|

--- a/spec/services/suggestion/suggestion_engine_spec.rb
+++ b/spec/services/suggestion/suggestion_engine_spec.rb
@@ -287,7 +287,7 @@ RSpec.describe Suggestion::SuggestionEngine do
         end
       end
 
-      context '関心ワードによるフィルタリング' do
+      context '関心トピックによるフィルタリング' do
         before { Suggestion::RuleRegistry.reload! }
 
         let(:user_without_concerns) { create(:user, prefecture: create(:prefecture)) }
@@ -316,7 +316,7 @@ RSpec.describe Suggestion::SuggestionEngine do
                  })
         end
 
-        it '関心ワード未登録の場合、general のルールのみ返す' do
+        it '関心トピック未登録の場合、general のルールのみ返す' do
           suggestions = described_class.call(user: user_without_concerns, date: date)
           heat_suggestion = suggestions.find { |s| s.key == 'heatstroke_Warning' }
           general_suggestions = suggestions.select do |s|
@@ -330,7 +330,7 @@ RSpec.describe Suggestion::SuggestionEngine do
           expect(suggestions).not_to be_empty
         end
 
-        it '関心ワード登録時、該当するルールのみ返す' do
+        it '関心トピック登録時、該当するルールのみ返す' do
           heat_topic = ConcernTopic.find_or_create_by!(key: 'heatstroke') do |c|
             c.label_ja = "熱中症"
             c.rule_concerns = [ "heatstroke" ]
@@ -357,7 +357,7 @@ RSpec.describe Suggestion::SuggestionEngine do
           expect(heat_suggestion.title).to eq('暑い日')
         end
 
-        it '登録した関心ワードに含まないルールは返さない' do
+        it '登録した関心トピックに含まないルールは返さない' do
           heat_topic = ConcernTopic.find_or_create_by!(key: 'heatstroke') do |c|
             c.label_ja = "熱中症"
             c.rule_concerns = [ "heatstroke" ]


### PR DESCRIPTION
# 概要
アプリ内の日本語表示で使用している「関心ワード」を「関心トピック」に統一する文言変更。

# 目的
- 「ワード（単語）」よりも「トピック（話題・テーマ）」の方が、健康関連の選択項目を表す文言として適切
- 英語識別子 `concern_topics` と日本語表示の整合性を取る

# 変更内容
- `spec/services/suggestion/suggestion_engine_spec.rb`: テスト説明文の「関心ワード」→「関心トピック」（4箇所）
- `db/seeds.rb`: コメントの「関心ワード」→「関心トピック」（3箇所）

# 影響範囲
- テスト説明文とコメントのみの変更。機能・API・DBへの影響なし

# 関連ブランチ名
- front: `refactor/front/rename-concern-word-to-topic`