### PR TITLE
Add production Host header validation

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -95,10 +95,9 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   # Enable DNS rebinding protection and other `Host` header attacks.
-  # config.hosts = [
-  #   "example.com",     # Allow requests from example.com
-  #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
-  # ]
+  config.hosts = [
+    ENV.fetch("RENDER_EXTERNAL_HOSTNAME", "climode-back.onrender.com")
+  ]
   # Skip DNS rebinding protection for the default health check endpoint.
-  # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+  config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 end


### PR DESCRIPTION
# 概要
本番環境（Render）の `config.hosts` を設定し、Host Header Injection 攻撃に対する防御を有効にする。

# 目的
- Host Header Injection 攻撃を防御する
- Rails のデフォルトセキュリティ機構を有効化する
- 本番環境のセキュリティを公開前に強化する

# 変更内容
- `config/environments/production.rb` で `config.hosts` のコメントアウトを解除
  - `RENDER_EXTERNAL_HOSTNAME` 環境変数を使用（Render が自動提供）
  - フォールバック値: `climode-back.onrender.com`
- `config.host_authorization` を設定し、ヘルスチェック `/up` を Host 検証から除外

# 影響範囲
- 本番環境のみに影響（development/test には影響なし）
- 不正な Host ヘッダーでのリクエストが 403 Forbidden で拒否されるようになる
- Render のヘルスチェックは `/up` 除外設定により正常動作する

# 関連ブランチ名
なし（バックエンドのみの変更）

Closes #108