### PR TITLE
Fix email duplication error in user_mailer_spec

### DIFF
--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -2,12 +2,12 @@ require "rails_helper"
 
 RSpec.describe UserMailer, type: :mailer do
   describe "#reset_password_email" do
-    let(:user) { create(:user, email: "test@example.com") }
+    let(:user) { create(:user) }
     let(:raw_token) { "test_reset_token_123" }
     let(:mail) { described_class.reset_password_email(user, raw_token) }
 
     it "正しい宛先に送信される" do
-      expect(mail.to).to eq([ "test@example.com" ])
+      expect(mail.to).to eq([ user.email ])
     end
 
     it "正しい件名が設定される" do
@@ -28,12 +28,12 @@ RSpec.describe UserMailer, type: :mailer do
   end
 
   describe "#confirmation_email" do
-    let(:user) { create(:user, email: "newuser@example.com") }
+    let(:user) { create(:user) }
     let(:raw_token) { "test_confirmation_token_456" }
     let(:mail) { described_class.confirmation_email(user, raw_token) }
 
     it "正しい宛先に送信される" do
-      expect(mail.to).to eq([ "newuser@example.com" ])
+      expect(mail.to).to eq([ user.email ])
     end
 
     it "正しい件名が設定される" do


### PR DESCRIPTION
# 概要
user_mailer_spec.rbでEmail重複エラーによりテストが失敗する問題を修正

# 目的
テストスイートが全件パスする状態にし、CI/ローカルでの安定したテスト実行を確保する

# 変更内容
- `spec/mailers/user_mailer_spec.rb`
  - `create(:user, email: "test@example.com")` → `create(:user)` に変更（ファクトリのシーケンスを利用）
  - `create(:user, email: "newuser@example.com")` → `create(:user)` に変更
  - メールアドレスの期待値をハードコードから `user.email` 参照に変更

# 影響範囲
テストのみ。本番コードへの変更なし。

# 関連ブランチ名
なし（バックエンドのみ）

Closes #109