### PR TITLE
Add custom domain (api.climode.app) support

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -82,7 +82,7 @@ Rails.application.configure do
     password: ENV["RESEND_API_KEY"],
     enable_starttls_auto: true
   }
-  config.action_mailer.default_url_options = { host: ENV.fetch("FRONTEND_URL", "https://climode-front.vercel.app") }
+  config.action_mailer.default_url_options = { host: ENV.fetch("FRONTEND_URL", "https://climode.app") }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
@@ -96,7 +96,8 @@ Rails.application.configure do
 
   # Enable DNS rebinding protection and other `Host` header attacks.
   config.hosts = [
-    ENV.fetch("RENDER_EXTERNAL_HOSTNAME", "climode-back.onrender.com")
+    ENV.fetch("RENDER_EXTERNAL_HOSTNAME", "climode-back.onrender.com"),
+    "api.climode.app"
   ]
   # Skip DNS rebinding protection for the default health check endpoint.
   config.host_authorization = { exclude: ->(request) { request.path == "/up" } }

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -3,7 +3,8 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
     origins [
       "http://front:3000",        # Docker内部
       "http://localhost:3000",    # ローカル開発
-      "https://climode-front.vercel.app"  # 本番環境
+      "https://climode.app",     # 本番環境（カスタムドメイン）
+      "https://climode-front.vercel.app"  # 本番環境（旧ドメイン・移行期間中）
     ]
     resource "*",
       headers: :any,


### PR DESCRIPTION
# 概要
カスタムドメイン `api.climode.app` に対応するためのバックエンド設定変更

# 目的
独自ドメインでAPIを公開し、プロフェッショナルなURL体系にする

# 変更内容
- CORS origins に `https://climode.app` を追加（旧ドメインも移行期間中残す）
- `production.rb` の `config.hosts` に `api.climode.app` を追加
- `action_mailer.default_url_options` のデフォルト値を `https://climode.app` に変更

# 影響範囲
- 本番環境のCORS設定
- 本番環境のホスト許可設定
- メール内リンクのデフォルトURL

# 関連ブランチ名
- Front: `chore/front/custom-domain`