### PR TITLE
Add health check endpoint to root path

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
 
   # Defines the root path route ("/")
-  # root "posts#index"
+  root "rails/health#show"
 
   namespace :api do
     namespace :v1 do

--- a/spec/requests/root_spec.rb
+++ b/spec/requests/root_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+
+RSpec.describe "Root path", type: :request do
+  describe "GET /" do
+    it "returns 200" do
+      get "/"
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end


### PR DESCRIPTION
# 概要
ルートパス（`/`）にヘルスチェックエンドポイントを設定

# 目的
Cloudflareプロキシからの定期的な `GET "/"` リクエストによる `ActionController::RoutingError` ログの抑制と、ルートURLアクセス時の適切なレスポンス返却

# 変更内容
- `config/routes.rb`: コメントアウトされていた `root` を `rails/health#show` に設定
- `spec/requests/root_spec.rb`: ルートパスが200を返すリクエストスペックを追加

# 影響範囲
ルートパス（`/`）へのアクセスのみ。既存のAPI（`/api/v1/*`）には影響なし

# 関連ブランチ名
なし（バックエンドのみの変更）