### PR TITLE
Fix email delivery by switching to deliver_now

### DIFF
--- a/app/controllers/api/v1/email_confirmations_controller.rb
+++ b/app/controllers/api/v1/email_confirmations_controller.rb
@@ -13,7 +13,7 @@ class Api::V1::EmailConfirmationsController < ApplicationController
     end
 
     raw_token = user.generate_confirmation_token!
-    UserMailer.confirmation_email(user, raw_token).deliver_later
+    UserMailer.confirmation_email(user, raw_token).deliver_now
 
     render json: { message: "確認メールを送信しました。メールをご確認ください。" }, status: :ok
   end

--- a/app/controllers/api/v1/password_resets_controller.rb
+++ b/app/controllers/api/v1/password_resets_controller.rb
@@ -22,7 +22,7 @@ class Api::V1::PasswordResetsController < ApplicationController
       end
 
       raw_token = user.generate_reset_password_token!
-      UserMailer.reset_password_email(user, raw_token).deliver_later
+      UserMailer.reset_password_email(user, raw_token).deliver_now
     end
 
     # ユーザー列挙防止: 存在有無に関わらず同じレスポンス

--- a/app/controllers/api/v1/registrations_controller.rb
+++ b/app/controllers/api/v1/registrations_controller.rb
@@ -5,7 +5,7 @@ class Api::V1::RegistrationsController < ApplicationController
     if user.save
       # メール確認トークンを生成して確認メールを送信
       raw_token = user.generate_confirmation_token!
-      UserMailer.confirmation_email(user, raw_token).deliver_later
+      UserMailer.confirmation_email(user, raw_token).deliver_now
 
       access_token = Auth::JwtService.generate_access_token(user)
 

--- a/spec/requests/api/v1/email_confirmations_controller_spec.rb
+++ b/spec/requests/api/v1/email_confirmations_controller_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe "Api::V1::EmailConfirmationsController", type: :request do
 
   before do
     Rack::Attack.enabled = false
-    ActiveJob::Base.queue_adapter = :test
+    ActionMailer::Base.delivery_method = :test
+    ActionMailer::Base.deliveries.clear
   end
 
   after do
@@ -21,7 +22,7 @@ RSpec.describe "Api::V1::EmailConfirmationsController", type: :request do
       it "確認メールを送信する" do
         expect {
           post "/api/v1/email_confirmation", headers: headers
-        }.to have_enqueued_mail(UserMailer, :confirmation_email)
+        }.to change { ActionMailer::Base.deliveries.count }.by(1)
 
         expect(response).to have_http_status(:ok)
         json = json_response
@@ -49,7 +50,7 @@ RSpec.describe "Api::V1::EmailConfirmationsController", type: :request do
       it "メールを送信しない" do
         expect {
           post "/api/v1/email_confirmation", headers: headers
-        }.not_to have_enqueued_mail(UserMailer, :confirmation_email)
+        }.not_to change { ActionMailer::Base.deliveries.count }
       end
     end
 

--- a/spec/requests/api/v1/password_resets_controller_spec.rb
+++ b/spec/requests/api/v1/password_resets_controller_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe "Api::V1::PasswordResetsController", type: :request do
 
   before do
     Rack::Attack.enabled = false
-    ActiveJob::Base.queue_adapter = :test
+    ActionMailer::Base.delivery_method = :test
+    ActionMailer::Base.deliveries.clear
   end
 
   after do
@@ -39,7 +40,7 @@ RSpec.describe "Api::V1::PasswordResetsController", type: :request do
           post "/api/v1/password_resets",
                params: { password_reset: { email: user.email } }.to_json,
                headers: { "Content-Type" => "application/json" }
-        }.to have_enqueued_mail(UserMailer, :reset_password_email)
+        }.to change { ActionMailer::Base.deliveries.count }.by(1)
       end
     end
 


### PR DESCRIPTION
# 概要
本番環境でメールが送信されない問題を修正する。

# 目的
ジョブキューシステム（Sidekiq等）が未導入の本番環境で、メール送信を確実に動作させる。

# 変更内容
- `deliver_later`（非同期）→ `deliver_now`（同期）に変更（3ファイル）
  - `registrations_controller.rb` — 新規登録時の確認メール
  - `email_confirmations_controller.rb` — 確認メール再送信
  - `password_resets_controller.rb` — パスワードリセットメール
- テストを `have_enqueued_mail` → `ActionMailer::Base.deliveries` ベースの検証に更新（2ファイル）

# 影響範囲
- メール送信処理のみ（同期/非同期の切り替え）
- ユーザー向けの動作・UIに変更なし
- DBマイグレーション不要

# 関連ブランチ名
なし（バックエンドのみの変更）

Closes #120