### PR TITLE
Fix email delivery by switching from SMTP to Resend HTTP API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,9 @@ gem "whenever", require: false
 gem "sentry-ruby"
 gem "sentry-rails"
 
+# Resend email delivery via HTTP API
+gem "resend"
+
 
 group :development do
   # メール確認用（ブラウザでメールプレビュー）

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -276,6 +276,8 @@ GEM
     regexp_parser (2.11.2)
     reline (0.6.2)
       io-console (~> 0.5)
+    resend (1.0.0)
+      httparty (>= 0.21.0)
     rexml (3.4.4)
     rspec (3.13.1)
       rspec-core (~> 3.13.0)
@@ -388,6 +390,7 @@ DEPENDENCIES
   rack-attack
   rack-cors
   rails (~> 7.2.0)
+  resend
   rspec-rails
   rubocop-rails-omakase
   sentry-rails

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -71,17 +71,9 @@ Rails.application.configure do
   # caching is enabled.
   config.action_mailer.perform_caching = false
 
-  # Resend SMTP設定
-  config.action_mailer.delivery_method = :smtp
+  # Resend HTTP API設定
+  config.action_mailer.delivery_method = :resend
   config.action_mailer.raise_delivery_errors = true
-  config.action_mailer.smtp_settings = {
-    address: "smtp.resend.com",
-    port: 587,
-    authentication: :plain,
-    user_name: "resend",
-    password: ENV["RESEND_API_KEY"],
-    enable_starttls_auto: true
-  }
   config.action_mailer.default_url_options = { host: ENV.fetch("FRONTEND_URL", "https://climode.app") }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to

--- a/config/initializers/resend.rb
+++ b/config/initializers/resend.rb
@@ -1,0 +1,1 @@
+Resend.api_key = ENV["RESEND_API_KEY"]


### PR DESCRIPTION
# 概要
本番環境（Render）でSMTPポート587への接続がタイムアウトする問題を、Resend HTTP API（ポート443）への切り替えで解消する。

# 目的
Renderのアウトバウンドポート制限を回避し、本番環境でのメール送信を確実に動作させる。

# 変更内容
- `resend` gem を追加（Gemfile / Gemfile.lock）
- `config/initializers/resend.rb` を新規作成（APIキー設定）
- `config/environments/production.rb` の `delivery_method` を `:smtp` → `:resend` に変更し、`smtp_settings` を削除

# 影響範囲
- 本番環境のメール送信経路のみ（SMTP → HTTP API）
- 開発環境（letter_opener_web）・テスト環境（:test）は変更なし
- ユーザー向けの動作・UIに変更なし

# 関連ブランチ名
なし（バックエンドのみの変更）

Closes #124