### PR TITLE
Fix email button visibility in confirmation and password reset emails

### DIFF
--- a/app/views/user_mailer/confirmation_email.html.erb
+++ b/app/views/user_mailer/confirmation_email.html.erb
@@ -9,7 +9,8 @@
     .logo { text-align: center; font-size: 24px; font-weight: bold; color: #1a1a2e; margin-bottom: 8px; }
     .subtitle { text-align: center; color: #6b7280; font-size: 14px; margin-bottom: 32px; }
     .message { color: #374151; font-size: 15px; line-height: 1.7; margin-bottom: 24px; }
-    .btn { display: block; width: fit-content; margin: 0 auto 24px; padding: 14px 32px; background-color: #4f46e5; color: #ffffff; text-decoration: none; border-radius: 8px; font-size: 15px; font-weight: 600; }
+    .btn-wrapper { text-align: center; margin-bottom: 24px; }
+    .btn { display: inline-block; padding: 16px 40px; background-color: #4f46e5; color: #ffffff !important; text-decoration: none; border-radius: 8px; font-size: 16px; font-weight: 700; letter-spacing: 0.5px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
     .note { color: #9ca3af; font-size: 13px; line-height: 1.6; }
     .footer { text-align: center; color: #9ca3af; font-size: 12px; margin-top: 32px; }
   </style>
@@ -24,7 +25,9 @@
       以下のボタンをクリックして、メールアドレスの確認を完了してください。
     </p>
 
-    <a href="<%= @confirmation_url %>" class="btn">メールアドレスを確認する</a>
+    <div class="btn-wrapper" style="text-align: center; margin-bottom: 24px;">
+      <a href="<%= @confirmation_url %>" class="btn" style="display: inline-block; padding: 16px 40px; background-color: #4f46e5; color: #ffffff !important; text-decoration: none; border-radius: 8px; font-size: 16px; font-weight: 700; letter-spacing: 0.5px; box-shadow: 0 2px 4px rgba(0,0,0,0.1);">メールアドレスを確認する</a>
+    </div>
 
     <p class="note">
       このリンクは24時間後に無効になります。<br>

--- a/app/views/user_mailer/reset_password_email.html.erb
+++ b/app/views/user_mailer/reset_password_email.html.erb
@@ -9,7 +9,8 @@
     .logo { text-align: center; font-size: 24px; font-weight: bold; color: #1a1a2e; margin-bottom: 8px; }
     .subtitle { text-align: center; color: #6b7280; font-size: 14px; margin-bottom: 32px; }
     .message { color: #374151; font-size: 15px; line-height: 1.7; margin-bottom: 24px; }
-    .btn { display: block; width: fit-content; margin: 0 auto 24px; padding: 14px 32px; background-color: #4f46e5; color: #ffffff; text-decoration: none; border-radius: 8px; font-size: 15px; font-weight: 600; }
+    .btn-wrapper { text-align: center; margin-bottom: 24px; }
+    .btn { display: inline-block; padding: 16px 40px; background-color: #4f46e5; color: #ffffff !important; text-decoration: none; border-radius: 8px; font-size: 16px; font-weight: 700; letter-spacing: 0.5px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
     .note { color: #9ca3af; font-size: 13px; line-height: 1.6; }
     .footer { text-align: center; color: #9ca3af; font-size: 12px; margin-top: 32px; }
   </style>
@@ -24,7 +25,9 @@
       以下のボタンをクリックして、新しいパスワードを設定してください。
     </p>
 
-    <a href="<%= @reset_url %>" class="btn">パスワードを再設定する</a>
+    <div class="btn-wrapper" style="text-align: center; margin-bottom: 24px;">
+      <a href="<%= @reset_url %>" class="btn" style="display: inline-block; padding: 16px 40px; background-color: #4f46e5; color: #ffffff !important; text-decoration: none; border-radius: 8px; font-size: 16px; font-weight: 700; letter-spacing: 0.5px; box-shadow: 0 2px 4px rgba(0,0,0,0.1);">パスワードを再設定する</a>
+    </div>
 
     <p class="note">
       このリンクは1時間後に無効になります。<br>


### PR DESCRIPTION
# 概要
確認メール・パスワードリセットメールのCTAボタンの視認性を改善

# 目的
メールクライアントによってはstyleタグが無視され、ボタンのテキストがデフォルトのリンク色で表示される問題を解決し、クリッカブルであることが一目でわかるデザインにする

# 変更内容
- `<a>`タグにインラインスタイルを追加（styleタグを無視するメールクライアント対応）
- `text-align: center`のラッパーdivでボタンを中央配置
- パディング増加（14px 32px → 16px 40px）、フォントサイズ・ウェイト強化
- `box-shadow`追加でクリッカブル感を向上
- `color: #ffffff !important`でリンク色上書きを防止

# 影響範囲
- `app/views/user_mailer/confirmation_email.html.erb`
- `app/views/user_mailer/reset_password_email.html.erb`

# 関連ブランチ名
なし（Back単体の変更）